### PR TITLE
build(deps): bump js-yaml from 1.4.0 to 1.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "js-yaml": "4.1.0"
+        "js-yaml": "4.1.1"
       }
     },
     "node_modules/argparse": {
@@ -19,9 +19,9 @@
       "license": "Python-2.0"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   "author": "lshadler <lshadler13@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "js-yaml": "4.1.0"
+    "js-yaml": "4.1.1"
   }
 }


### PR DESCRIPTION
fix security issue with prototype pollution https://github.com/nodeca/js-yaml/commit/383665ff4248ec2192d1274e934462bb30426879

Spotted while updating main app depency on js-yaml.

https://github.com/Crowd9/Gleam/pull/30970